### PR TITLE
Issue 13: Added checks for vagrantfile before running commands that a…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,10 +78,20 @@ connect-hub:
 	@VAGRANT_VAGRANTFILE=$(VAGRANT_HUB) vagrant ssh
 
 connect:
-	@VAGRANT_VAGRANTFILE=$(VAGRANT_VAGRANTFILE) vagrant ssh $(VMNAME)
+	@if [ -f $(VAGRANT_VAGRANTFILE) ]; then \
+		VAGRANT_VAGRANTFILE=$(VAGRANT_VAGRANTFILE) vagrant ssh $(VMNAME); \
+	else \
+		echo "Error: Vagrantfile not found at $(VAGRANT_VAGRANTFILE). Run 'make up' first to generate it."; \
+		exit 1; \
+	fi
 
 status:
-	@VAGRANT_VAGRANTFILE=$(VAGRANT_VAGRANTFILE) vagrant status
+	@if [ -f $(VAGRANT_VAGRANTFILE) ]; then \
+		VAGRANT_VAGRANTFILE=$(VAGRANT_VAGRANTFILE) vagrant status; \
+	else \
+		echo "Error: Vagrantfile not found at $(VAGRANT_VAGRANTFILE). Run 'make up' first to generate it."; \
+		exit 1; \
+	fi
 
 status-hub:
 	@VAGRANT_VAGRANTFILE=$(VAGRANT_HUB) vagrant status


### PR DESCRIPTION
…ssume it exists

## Issues

 I've successfully modified both the connect and status targets in the Makefile to include IF blocks that check if the VAGRANT_VAGRANTFILE exists before executing the commands. Here's what I changed:

- connect target: Now checks if $(VAGRANT_VAGRANTFILE) exists before running the vagrant ssh command. If the file doesn't exist, it displays an error message and exits with code 1.
- status target: Similarly checks if $(VAGRANT_VAGRANTFILE) exists before running the vagrant status command. If the file doesn't exist, it displays an error message and exits with code 1.
- The changes use shell IF statements with proper error handling:
- If the file exists, the original vagrant command is executed
- If the file doesn't exist, an informative error message is displayed suggesting to run make up first, and the command exits with an error code

This will prevent errors when trying to run make connect or make status before the Vagrantfile has been generated by the make up command.

Fixes #13 

